### PR TITLE
Remove vertical scroll bar in Chrome on Windows

### DIFF
--- a/www/static/css/style.css
+++ b/www/static/css/style.css
@@ -3,6 +3,7 @@ body {
   font-family: 'Roboto', sans-serif;
   color:#ECF0F1;
   font-weight:300;
+  margin: 0;
 }
 .aligner {
     height: 100vh;


### PR DESCRIPTION
.aligner has a height of 100vh, and the body still has its default margins, so the total height is greater than 100vh, triggering vertical scrollbars in Chrome on Windows. Removing the default margin hides the scroll bar when there is plenty of space for the weather.