### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-###React Weather
+### React Weather
 
 Example React weather application that uses [Forecast.io](https://developer.forecast.io) API and Google Maps for Geocoding.
 
@@ -6,11 +6,11 @@ Build as part of an Intro to React [Code Club](http://codeclub.im/2014/07/introd
 
 Includes `server.go`, a simple Go-based JSON API to handle geocoding and interfacing with Forecast's API.
 
-###Getting started
+### Getting started
 
 To get up and running, you'll need to set `rootAssetPath` to the absolute path of your cloned repo, and replace the placeholder string in `forecastURL` with your own key.
 
-###Usage
+### Usage
 
 Click the location text to show the location search input. Click anywhere on app itself to show an hourly breakdown of the weather for the next 24 hours.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
